### PR TITLE
Fix build issues when run 'mvn clean install' with JDK 9

### DIFF
--- a/wsit/bundles/webservices-api-osgi/pom.xml
+++ b/wsit/bundles/webservices-api-osgi/pom.xml
@@ -208,6 +208,9 @@
    <profiles>
         <profile>
             <id>release-9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
             <build>
                 <plugins>
                   <plugin>

--- a/wsit/bundles/webservices-api/pom.xml
+++ b/wsit/bundles/webservices-api/pom.xml
@@ -171,6 +171,9 @@
     <profiles>
         <profile>
             <id>release-9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
             <build>
               <plugins>
                 <plugin>

--- a/wsit/bundles/webservices-extra-api/pom.xml
+++ b/wsit/bundles/webservices-extra-api/pom.xml
@@ -137,6 +137,9 @@
     <profiles>
         <profile>
             <id>release-9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
             <build>
               <plugins>
                 <plugin>

--- a/wsit/bundles/webservices-extra/pom.xml
+++ b/wsit/bundles/webservices-extra/pom.xml
@@ -166,6 +166,9 @@
     <profiles>
         <profile>
             <id>release-9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
             <build>
               <plugins>
                  <plugin>

--- a/wsit/bundles/webservices-osgi-aix/pom.xml
+++ b/wsit/bundles/webservices-osgi-aix/pom.xml
@@ -331,6 +331,9 @@
     <profiles>
         <profile>
             <id>release-9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
             <build>
                 <plugins>
                     <plugin>

--- a/wsit/bundles/webservices-osgi/pom.xml
+++ b/wsit/bundles/webservices-osgi/pom.xml
@@ -329,6 +329,9 @@
    <profiles>
         <profile>
             <id>release-9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
             <build>
               <plugins>
                  <plugin>

--- a/wsit/bundles/webservices-rt/pom.xml
+++ b/wsit/bundles/webservices-rt/pom.xml
@@ -319,6 +319,9 @@
     <profiles>
         <profile>
             <id>release-9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
             <build>
               <plugins>
                 <plugin>

--- a/wsit/bundles/webservices-tools/pom.xml
+++ b/wsit/bundles/webservices-tools/pom.xml
@@ -190,6 +190,9 @@
 
         <profile>
             <id>release-9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
             <build>
                 <pluginManagement>
                     <plugins>

--- a/wsit/bundles/wsit-impl/pom.xml
+++ b/wsit/bundles/wsit-impl/pom.xml
@@ -239,6 +239,9 @@
     <profiles>
         <profile>
             <id>release-9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
             <build>
               <plugins>
                 <plugin>

--- a/wsit/metro-config/metro-config-impl/pom.xml
+++ b/wsit/metro-config/metro-config-impl/pom.xml
@@ -92,9 +92,9 @@
     <profiles>
         <profile>
             <id>release-9</id>
-              <activation>
-                <jdk>9</jdk>
-              </activation>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
             <build>
               <plugins>
                 <plugin>

--- a/wsit/metro-runtime/metro-runtime-impl/pom.xml
+++ b/wsit/metro-runtime/metro-runtime-impl/pom.xml
@@ -79,7 +79,7 @@
         <profile>
             <id>release-9</id>
             <activation>
-                <jdk>9</jdk>
+                <jdk>[9,)</jdk>
             </activation>
             <build>
               <plugins>

--- a/wsit/pom.xml
+++ b/wsit/pom.xml
@@ -589,6 +589,9 @@
 
         <profile>
             <id>release-9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
             <build>
                 <plugins>
                     <plugin>

--- a/wsit/ws-sx/wssx-impl/pom.xml
+++ b/wsit/ws-sx/wssx-impl/pom.xml
@@ -237,6 +237,9 @@
     <profiles>
         <profile>
             <id>release-9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
             <build>
                 <plugins>
                     <plugin>

--- a/wsit/ws-tx/wstx-impl/pom.xml
+++ b/wsit/ws-tx/wstx-impl/pom.xml
@@ -76,6 +76,9 @@
     <profiles>
        <profile>
           <id>release-9</id>
+           <activation>
+               <jdk>[9,)</jdk>
+           </activation>
            <build>
              <plugins>
                <plugin>


### PR DESCRIPTION
Fix build issues when run 'mvn clean install' with JDK 9.
@lukasj @bravehorsie @m0mus @HOHOWU @Xiaojwu @yuHe1 